### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: "develop" 


### PR DESCRIPTION
## Description:

This PR updates the `dependabot.yml` configuration to change the default target branch for Dependabot pull requests from `main` to `develop`. 

## Changes:
- Set the `target-branch` in `.github/dependabot.yml` to `develop`.
  
This will ensure that all future dependency updates will be merged into the `develop` branch instead of the `main` branch, aligning with our development workflow.
