### PR TITLE
Remove the fixed Node.js version and specify version management using Volta.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,9 +65,6 @@
         "vite": "^5.4.4",
         "vite-plugin-css-injected-by-js": "^3.5.2",
         "vite-plugin-dts": "^4.2.3"
-      },
-      "engines": {
-        "node": "20"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "relmethis",
   "version": "0.1.81",
-  "engines": {
-    "node": "20"
-  },
   "author": "Chomolungma Shirayuki",
   "repository": {
     "type": "git",
@@ -95,5 +92,8 @@
     "vite": "^5.4.4",
     "vite-plugin-css-injected-by-js": "^3.5.2",
     "vite-plugin-dts": "^4.2.3"
+  },
+  "volta": {
+    "node": "22.9.0"
   }
 }


### PR DESCRIPTION
With this change, users of this npm module are no longer restricted to a specific Node.js version, while developers of the module can still lock the Node.js version for development purposes.
